### PR TITLE
Bugfix: Popen.wait() causes deadlock

### DIFF
--- a/buildcache
+++ b/buildcache
@@ -230,8 +230,7 @@ def check_md5sum():
     if not os.path.exists(cache_dir):
         return False
     p = subprocess.Popen(['md5sum', '-c', os.path.join(cache_dir, 'buildcache.md5sum')], stdout=subprocess.PIPE)
-    p.wait()
-    result = p.stdout.read()
+    result = p.communicate()[0]
     if debug:
         print result
     elif 1 or verbose:


### PR DESCRIPTION
Popen.wait() can cause deadlock if child process generated enough
output such that it blocks waiting for OS pipe buffer to accept
more data.

Ref: https://docs.python.org/2/library/subprocess.html
